### PR TITLE
Update NuGet package versions across solution

### DIFF
--- a/SecurityService.BusinessLogic/SecurityService.BusinessLogic.csproj
+++ b/SecurityService.BusinessLogic/SecurityService.BusinessLogic.csproj
@@ -9,15 +9,15 @@
     <PackageReference Include="Duende.IdentityServer.EntityFramework.Storage" Version="7.4.6" />
     <PackageReference Include="Duende.IdentityServer.Storage" Version="7.4.6" />
     <PackageReference Include="MediatR" Version="14.0.0" />
-    <PackageReference Include="MessagingService.Client" Version="2025.12.1" />
+    <PackageReference Include="MessagingService.Client" Version="2026.2.1" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="10.0.3" />
     <PackageReference Include="Microsoft.AspNetCore.Identity" Version="2.3.9" />
     <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="10.0.3" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.3" />
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.3" />
     <PackageReference Include="Microsoft.Extensions.Identity.Core" Version="10.0.3" />
-    <PackageReference Include="Shared" Version="2026.2.1" />
-    <PackageReference Include="Shared.Results" Version="2026.2.1" />
+    <PackageReference Include="Shared" Version="2026.2.2" />
+    <PackageReference Include="Shared.Results" Version="2026.2.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/SecurityService.Client/SecurityService.Client.csproj
+++ b/SecurityService.Client/SecurityService.Client.csproj
@@ -6,8 +6,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="ClientProxyBase" Version="2026.2.1" />
-    <PackageReference Include="Shared.Results" Version="2026.2.1" />
+    <PackageReference Include="ClientProxyBase" Version="2026.2.2" />
+    <PackageReference Include="Shared.Results" Version="2026.2.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/SecurityService.Database/SecurityService.Database.csproj
+++ b/SecurityService.Database/SecurityService.Database.csproj
@@ -22,7 +22,7 @@
 		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
 		<PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.3" />
-		<PackageReference Include="Shared" Version="2026.2.1" />
+		<PackageReference Include="Shared" Version="2026.2.2" />
 	</ItemGroup>
 	<ItemGroup>
     <Folder Include="DbContexts\" />

--- a/SecurityService.IntegrationTesting.Helpers/SecurityService.IntegrationTesting.Helpers.csproj
+++ b/SecurityService.IntegrationTesting.Helpers/SecurityService.IntegrationTesting.Helpers.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.3" />
-    <PackageReference Include="Shared.IntegrationTesting" Version="2026.2.1" />
+    <PackageReference Include="Shared.IntegrationTesting" Version="2026.2.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/SecurityService.IntegrationTests/SecurityService.IntegrationTests.csproj
+++ b/SecurityService.IntegrationTests/SecurityService.IntegrationTests.csproj
@@ -14,7 +14,7 @@
     
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.3" />
     
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
     
     <PackageReference Include="Reqnroll" Version="3.3.3" />
     
@@ -24,7 +24,7 @@
     <PackageReference Include="NUnit3TestAdapter" Version="6.1.0" />
     <PackageReference Include="Reqnroll.NUnit" Version="3.3.3" />
 
-    <PackageReference Include="Shared.IntegrationTesting" Version="2026.2.1" />
+    <PackageReference Include="Shared.IntegrationTesting" Version="2026.2.2" />
     <PackageReference Include="System.Data.SqlClient" Version="4.9.1" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.3" />
     

--- a/SecurityService.OpenIdConnect.IntegrationTests/SecurityService.OpenIdConnect.IntegrationTests.csproj
+++ b/SecurityService.OpenIdConnect.IntegrationTests/SecurityService.OpenIdConnect.IntegrationTests.csproj
@@ -12,7 +12,7 @@
     
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.3" />
 
-	  <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
+	  <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
 
     <PackageReference Include="Reqnroll" Version="3.3.3" />
 
@@ -24,7 +24,7 @@
     
     <PackageReference Include="Selenium.Support" Version="4.41.0" />
     <PackageReference Include="Selenium.WebDriver" Version="4.41.0" />
-    <PackageReference Include="Shared.IntegrationTesting" Version="2026.2.1" />
+    <PackageReference Include="Shared.IntegrationTesting" Version="2026.2.2" />
     <PackageReference Include="coverlet.collector" Version="8.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/SecurityService.UnitTests/SecurityService.UnitTests.csproj
+++ b/SecurityService.UnitTests/SecurityService.UnitTests.csproj
@@ -15,7 +15,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="10.0.3" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.3" />
     <PackageReference Include="Microsoft.Extensions.Hosting.WindowsServices" Version="10.0.3" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.3" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.3" />
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.3" />

--- a/SecurityService.UserInterface/SecurityService.UserInterface.csproj
+++ b/SecurityService.UserInterface/SecurityService.UserInterface.csproj
@@ -16,7 +16,7 @@
 		<PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="10.0.3" />
 		<PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.3" />
 		<PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.3" />
-		<PackageReference Include="Shared" Version="2026.2.1" />
+		<PackageReference Include="Shared" Version="2026.2.2" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/SecurityService/SecurityService.csproj
+++ b/SecurityService/SecurityService.csproj
@@ -32,10 +32,10 @@
     </PackageReference>
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.3" />
 	  <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.3" />
-	  <PackageReference Include="ClientProxyBase" Version="2026.2.1" />
+	  <PackageReference Include="ClientProxyBase" Version="2026.2.2" />
     <PackageReference Include="Serilog.AspNetCore" Version="10.0.0" />
-	  <PackageReference Include="Shared" Version="2026.2.1" />
-    <PackageReference Include="Shared.Results.Web" Version="2026.2.1" />
+	  <PackageReference Include="Shared" Version="2026.2.2" />
+    <PackageReference Include="Shared.Results.Web" Version="2026.2.2" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="10.1.4" />
     <PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="10.1.4" />
     <PackageReference Include="Swashbuckle.AspNetCore.Filters" Version="10.0.1" />

--- a/SecurityServiceTestUI/SecurityServiceTestUI.csproj
+++ b/SecurityServiceTestUI/SecurityServiceTestUI.csproj
@@ -11,7 +11,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="10.0.3" />
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.3" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.23.0" />
-    <PackageReference Include="Shared" Version="2026.2.1" />
+    <PackageReference Include="Shared" Version="2026.2.2" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Upgraded Shared, Shared.Results, Shared.IntegrationTesting, Shared.Results.Web, and ClientProxyBase to 2026.2.2. Updated MessagingService.Client to 2026.2.1 and Microsoft.NET.Test.Sdk to 18.3.0 in test projects. These updates bring in the latest fixes and improvements from dependencies.

closes #1041 