### PR TITLE
Make Sentry options configurable via app settings

### DIFF
--- a/SecurityService/Program.cs
+++ b/SecurityService/Program.cs
@@ -72,7 +72,8 @@ builder.WebHost.ConfigureAppConfiguration((context, configBuilder) =>
                 o.Dsn = builtConfig["SentryConfiguration:Dsn"];
                 o.SendDefaultPii = true;
                 o.MaxRequestBodySize = RequestSize.Always;
-                o.CaptureBlockingCalls = true;
+                o.CaptureBlockingCalls = ConfigurationReader.GetValueOrDefault("SentryConfiguration", "CaptureBlockingCalls", false);
+                o.IncludeActivityData = ConfigurationReader.GetValueOrDefault("SentryConfiguration", "IncludeActivityData", false);
                 o.Release = Assembly.GetExecutingAssembly().GetName().Version?.ToString() ?? "unknown";
             });
         }


### PR DESCRIPTION
CaptureBlockingCalls and IncludeActivityData are now read from configuration using ConfigurationReader.GetValueOrDefault, defaulting to false if not set. This allows these Sentry options to be controlled externally rather than hardcoded.

closes #1065 