### PR TITLE
Update packages and migrate from Newtonsoft.Json to System.Text.Json

### DIFF
--- a/SecurityService.BusinessLogic/SecurityService.BusinessLogic.csproj
+++ b/SecurityService.BusinessLogic/SecurityService.BusinessLogic.csproj
@@ -6,14 +6,14 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="MediatR" Version="14.1.0" />
-    <PackageReference Include="MessagingService.Client" Version="2026.3.2" />
+    <PackageReference Include="MessagingService.Client" Version="2026.4.3-build126" />
     <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="10.0.5" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.5" />
     <PackageReference Include="OpenIddict.Abstractions" Version="7.3.0" />
     <PackageReference Include="OpenIddict.Server" Version="7.3.0" />
     <PackageReference Include="OpenIddict.Server.AspNetCore" Version="7.3.0" />
     <PackageReference Include="OpenIddict.Validation.AspNetCore" Version="7.3.0" />
-    <PackageReference Include="Shared.Results" Version="2026.5.4" />
+    <PackageReference Include="Shared.Results" Version="2026.5.5" />
     <PackageReference Include="SimpleResults" Version="4.0.0" />
   </ItemGroup>
   <ItemGroup>

--- a/SecurityService.Client/SecurityService.Client.csproj
+++ b/SecurityService.Client/SecurityService.Client.csproj
@@ -6,8 +6,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="ClientProxyBase" Version="2026.5.4" />
-    <PackageReference Include="Shared.Results" Version="2026.5.4" />
+    <PackageReference Include="ClientProxyBase" Version="2026.5.5" />
+    <PackageReference Include="Shared.Results" Version="2026.5.5" />
   </ItemGroup>
 
   <ItemGroup>

--- a/SecurityService.DataTransferObjects/Responses.cs
+++ b/SecurityService.DataTransferObjects/Responses.cs
@@ -1,5 +1,5 @@
-﻿using Newtonsoft.Json;
-using System.Text.Json.Serialization;
+﻿
+using System.Text.Json;
 
 namespace SecurityService.DataTransferObjects;
 
@@ -100,21 +100,20 @@ public class TokenResponse
     public Int64 ExpiresIn { get; private set; }
     public DateTimeOffset Issued { get; private set; }
     public String RefreshToken { get; private set; }
-    public static TokenResponse Create(String token)
-    {
-        dynamic auth = JsonConvert.DeserializeObject(token);
+    public static TokenResponse Create(String token) {
+        using var doc = JsonDocument.Parse(token);
+        var root = doc.RootElement;
 
-        Int64 expiresIn = auth["expires_in"].Value;
-        String accessToken = auth["access_token"].Value;
+        long expiresIn = root.GetProperty("expires_in").GetInt64();
+        string accessToken = root.GetProperty("access_token").GetString();
 
         DateTimeOffset issued = DateTimeOffset.Now;
-        DateTimeOffset expires = DateTimeOffset.Now.AddSeconds(expiresIn);
+        DateTimeOffset expires = issued.AddSeconds(expiresIn);
 
-        String refreshToken = null;
-        //For client credentials, the refresh_token will not be present
-        if (auth["refresh_token"] != null)
+        string refreshToken = null;
+        if (root.TryGetProperty("refresh_token", out var refreshElement))
         {
-            refreshToken = auth["refresh_token"].Value;
+            refreshToken = refreshElement.GetString();
         }
 
         return TokenResponse.Create(accessToken, refreshToken, expiresIn, issued, expires);

--- a/SecurityService.DataTransferObjects/SecurityService.DataTransferObjects.csproj
+++ b/SecurityService.DataTransferObjects/SecurityService.DataTransferObjects.csproj
@@ -5,6 +5,6 @@
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
+    
   </ItemGroup>
 </Project>

--- a/SecurityService.IntegrationTesting.Helpers/SecurityService.IntegrationTesting.Helpers.csproj
+++ b/SecurityService.IntegrationTesting.Helpers/SecurityService.IntegrationTesting.Helpers.csproj
@@ -10,7 +10,7 @@
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.3" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.5" />
 	  <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="10.0.5" />
-    <PackageReference Include="Shared.IntegrationTesting" Version="2026.5.4" />
+    <PackageReference Include="Shared.IntegrationTesting" Version="2026.5.5" />
   </ItemGroup>
 
   <ItemGroup>

--- a/SecurityService.IntegrationTests/ApiResource/ApiResourceSteps.cs
+++ b/SecurityService.IntegrationTests/ApiResource/ApiResourceSteps.cs
@@ -12,7 +12,6 @@ namespace SecurityService.IntegrationTests.ApiResource
     using Clients;
     using IntegrationTesting.Helpers;
     using IntergrationTests.Common;
-    using Newtonsoft.Json;
     using Reqnroll;
     using Shouldly;
 

--- a/SecurityService.IntegrationTests/SecurityService.IntegrationTests.csproj
+++ b/SecurityService.IntegrationTests/SecurityService.IntegrationTests.csproj
@@ -24,7 +24,7 @@
     <PackageReference Include="NUnit3TestAdapter" Version="6.1.0" />
     <PackageReference Include="Reqnroll.NUnit" Version="3.3.3" />
 
-    <PackageReference Include="Shared.IntegrationTesting" Version="2026.5.4" />
+    <PackageReference Include="Shared.IntegrationTesting" Version="2026.5.5" />
     <PackageReference Include="System.Data.SqlClient" Version="4.9.1" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.5" />
     

--- a/SecurityService.IntegrationTests/Users/UsersSteps.cs
+++ b/SecurityService.IntegrationTests/Users/UsersSteps.cs
@@ -10,7 +10,6 @@
     using Common;
     using DataTransferObjects;
     using IntegrationTesting.Helpers;
-    using Newtonsoft.Json;
     using Reqnroll;
     using Shouldly;
 

--- a/SecurityService.OpenIdConnect.IntegrationTests/Common/DockerHelper.cs
+++ b/SecurityService.OpenIdConnect.IntegrationTests/Common/DockerHelper.cs
@@ -8,7 +8,6 @@ using System.Runtime.InteropServices;
 namespace SecurityService.IntergrationTests.Common
 {
     using Client;
-    using Newtonsoft.Json;
     using Shared.HealthChecks;
     using Shared.IntegrationTesting;
     using Shared.Logger;
@@ -119,7 +118,7 @@ namespace SecurityService.IntergrationTests.Common
                                     await this.HealthCheckClient.PerformHealthCheck("https", "127.0.0.1", this.SecurityServiceTestUIPort, CancellationToken.None);
 
                                 healthCheck.IsSuccess.ShouldBeTrue($"Health check for Test UI failed with [{healthCheck.Message}]");
-                                HealthCheckResult result = JsonConvert.DeserializeObject<HealthCheckResult>(healthCheck.Data);
+                                HealthCheckResult result = StringSerialiser.Deserialise<HealthCheckResult>(healthCheck.Data);
 
                                 this.Trace($"health check complete for Test UI result is [{healthCheck}]");
 

--- a/SecurityService.OpenIdConnect.IntegrationTests/Common/DockerHelper.cs
+++ b/SecurityService.OpenIdConnect.IntegrationTests/Common/DockerHelper.cs
@@ -4,6 +4,7 @@ using DotNet.Testcontainers.Containers;
 using DotNet.Testcontainers.Networks;
 using Shared.IntegrationTesting.TestContainers;
 using System.Runtime.InteropServices;
+using System.Text.Json;
 
 namespace SecurityService.IntergrationTests.Common
 {
@@ -56,7 +57,7 @@ namespace SecurityService.IntergrationTests.Common
         /// <param name="logger">The logger.</param>
         public DockerHelper() : base()
         {
-            StringSerialiser.Initialise(new SerialiserOptions(SerialiserPropertyFormat.SnakeCase));
+            StringSerialiser.Initialise(new SystemTextJsonSerializer(SystemTextJsonSerializer.GetDefaultJsonSerializerOptions()));
         }
 
         #endregion

--- a/SecurityService.OpenIdConnect.IntegrationTests/Common/DockerHelper.cs
+++ b/SecurityService.OpenIdConnect.IntegrationTests/Common/DockerHelper.cs
@@ -56,7 +56,7 @@ namespace SecurityService.IntergrationTests.Common
         /// <param name="logger">The logger.</param>
         public DockerHelper() : base()
         {
-            
+            StringSerialiser.Initialise(new SerialiserOptions(SerialiserPropertyFormat.SnakeCase));
         }
 
         #endregion

--- a/SecurityService.OpenIdConnect.IntegrationTests/ForgotPassword/ForgotPasswordSteps.cs
+++ b/SecurityService.OpenIdConnect.IntegrationTests/ForgotPassword/ForgotPasswordSteps.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using Shared.Serialisation;
 
 namespace SecurityService.OpenIdConnect.IntegrationTests.ForgotPassword
 {
@@ -11,7 +12,6 @@ namespace SecurityService.OpenIdConnect.IntegrationTests.ForgotPassword
     using System.Threading;
     using HtmlAgilityPack;
     using IntergrationTests.Common;
-    using Newtonsoft.Json;
     using OpenQA.Selenium;
     using Reqnroll;
     using SecurityService.IntegrationTests.UserLogin;
@@ -87,7 +87,7 @@ namespace SecurityService.OpenIdConnect.IntegrationTests.ForgotPassword
                                        MessageId = Guid.Empty,
                                        Body = String.Empty
                                    };
-            var x = JsonConvert.DeserializeAnonymousType(await response.Content.ReadAsStringAsync(CancellationToken.None), emailMessage);
+            var x = StringSerialiser.DeserialiseAnonymousType(await response.Content.ReadAsStringAsync(CancellationToken.None), emailMessage);
 
             var doc = new HtmlDocument();
             doc.LoadHtml(x.Body);

--- a/SecurityService.OpenIdConnect.IntegrationTests/SecurityService.OpenIdConnect.IntegrationTests.csproj
+++ b/SecurityService.OpenIdConnect.IntegrationTests/SecurityService.OpenIdConnect.IntegrationTests.csproj
@@ -24,7 +24,7 @@
     
     <PackageReference Include="Selenium.Support" Version="4.41.0" />
     <PackageReference Include="Selenium.WebDriver" Version="4.41.0" />
-    <PackageReference Include="Shared.IntegrationTesting" Version="2026.5.4" />
+    <PackageReference Include="Shared.IntegrationTesting" Version="2026.5.5" />
     <PackageReference Include="coverlet.collector" Version="8.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/SecurityService.OpenIdConnect.IntegrationTests/UserLogin/UserLoginSteps.cs
+++ b/SecurityService.OpenIdConnect.IntegrationTests/UserLogin/UserLoginSteps.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using Shared.Serialisation;
 
 namespace SecurityService.IntegrationTests.UserLogin
 {
@@ -12,7 +13,6 @@ namespace SecurityService.IntegrationTests.UserLogin
     using System.Threading.Tasks;
     using HtmlAgilityPack;
     using IntergrationTests.Common;
-    using Newtonsoft.Json;
     using OpenQA.Selenium;
     using Reqnroll;
     using Shared.IntegrationTesting;
@@ -112,7 +112,7 @@ namespace SecurityService.IntegrationTests.UserLogin
                                    MessageId = Guid.Empty,
                                    Body = String.Empty
                                };
-            var x = JsonConvert.DeserializeAnonymousType(await response.Content.ReadAsStringAsync(CancellationToken.None), emailMessage);
+            var x = StringSerialiser.DeserialiseAnonymousType(await response.Content.ReadAsStringAsync(CancellationToken.None), emailMessage);
 
             HtmlDocument doc = new HtmlDocument();
             doc.LoadHtml(x.Body);
@@ -140,7 +140,7 @@ namespace SecurityService.IntegrationTests.UserLogin
                                    MessageId = Guid.Empty,
                                    Body = String.Empty
                                };
-            var x = JsonConvert.DeserializeAnonymousType(await response.Content.ReadAsStringAsync(CancellationToken.None), emailMessage);
+            var x = StringSerialiser.DeserialiseAnonymousType(await response.Content.ReadAsStringAsync(CancellationToken.None), emailMessage);
 
             HtmlDocument doc = new HtmlDocument();
             doc.LoadHtml(x.Body);

--- a/SecurityService/SecurityService.csproj
+++ b/SecurityService/SecurityService.csproj
@@ -19,7 +19,6 @@
     <PackageReference Include="MediatR" Version="14.1.0" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="10.0.5" />
     <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="10.0.5" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="10.0.5" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.5" />
     <PackageReference Include="Microsoft.Extensions.Hosting.WindowsServices" Version="10.0.5" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.5">
@@ -33,8 +32,8 @@
     <PackageReference Include="OpenIddict.EntityFrameworkCore" Version="7.3.0" />
     <PackageReference Include="OpenIddict.Server.AspNetCore" Version="7.3.0" />
     <PackageReference Include="OpenIddict.Validation.AspNetCore" Version="7.3.0" />
-    <PackageReference Include="Shared" Version="2026.5.4" />
-    <PackageReference Include="Shared.Results.Web" Version="2026.5.4" />
+    <PackageReference Include="Shared" Version="2026.5.5" />
+    <PackageReference Include="Shared.Results.Web" Version="2026.5.5" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="10.0.1" />
     <PackageReference Include="Sentry.AspNetCore" Version="6.2.0" />
     <PackageReference Include="NLog.Web.AspNetCore" Version="6.1.2" />

--- a/SecurityServiceTestUI/SecurityServiceTestUI.csproj
+++ b/SecurityServiceTestUI/SecurityServiceTestUI.csproj
@@ -11,7 +11,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="10.0.3" />
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.3" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.23.0" />
-    <PackageReference Include="Shared" Version="2026.5.4" />
+    <PackageReference Include="Shared" Version="2026.5.5" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Bump Shared, Results, IntegrationTesting, and related NuGet packages to 2026.5.5. Update MessagingService.Client and ClientProxyBase versions. Remove Newtonsoft.Json and Microsoft.AspNetCore.Mvc.NewtonsoftJson dependencies. Refactor code to use System.Text.Json and Shared.Serialisation.StringSerialiser for all (de)serialization, affecting DTOs and integration tests.

closes #1556 