### PR TITLE
Centralize NuGet package versions with Directory.Packages.props

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,0 +1,56 @@
+<Project>
+  <PropertyGroup>
+	<ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+  </PropertyGroup>
+  <ItemGroup>
+	<PackageVersion Include="MediatR" Version="14.1.0" />
+	<PackageVersion Include="MessagingService.Client" Version="2026.5.1" />
+	<PackageVersion Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="10.0.9" />
+	<PackageVersion Include="Microsoft.EntityFrameworkCore" Version="10.0.9" />
+	<PackageVersion Include="OpenIddict.Abstractions" Version="7.5.0" />
+	<PackageVersion Include="OpenIddict.Server" Version="7.5.0" />
+	<PackageVersion Include="OpenIddict.Server.AspNetCore" Version="7.5.0" />
+	<PackageVersion Include="OpenIddict.Validation.AspNetCore" Version="7.5.0" />
+	<PackageVersion Include="Shared.Logger" Version="2026.5.7" />
+	<PackageVersion Include="Shared.Results" Version="2026.5.7" />
+	<PackageVersion Include="SimpleResults" Version="4.0.0" />
+	<PackageVersion Include="coverlet.msbuild" Version="10.0.1" />
+	<PackageVersion Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.9" />
+	<PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
+	<PackageVersion Include="Moq" Version="4.20.72" />
+	<PackageVersion Include="Shouldly" Version="4.3.0" />
+	<PackageVersion Include="xunit.v3" Version="3.2.2" />
+	<PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
+	<PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.9" />
+	<PackageVersion Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.9" />
+	<PackageVersion Include="OpenIddict.EntityFrameworkCore" Version="7.5.0" />
+	<PackageVersion Include="Microsoft.EntityFrameworkCore.Tools" Version="10.0.9" />
+	<PackageVersion Include="ClientProxyBase" Version="2026.5.7" />
+	<PackageVersion Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="10.0.9" />
+	<PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.9" />
+	<PackageVersion Include="Reqnroll" Version="3.3.4" />
+	<PackageVersion Include="Reqnroll.Tools.MsBuild.Generation" Version="3.3.4" />
+	<PackageVersion Include="NUnit" Version="4.6.1" />
+	<PackageVersion Include="NUnit3TestAdapter" Version="6.2.0" />
+	<PackageVersion Include="Reqnroll.NUnit" Version="3.3.3" />
+	<PackageVersion Include="Shared.IntegrationTesting" Version="2026.5.7" />
+	<PackageVersion Include="System.Data.SqlClient" Version="4.9.1" />
+	<PackageVersion Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.9" />
+	<PackageVersion Include="coverlet.collector" Version="10.0.1" />
+	<PackageVersion Include="Ductus.FluentDocker" Version="2.85.0" />
+	<PackageVersion Include="AspNetCore.HealthChecks.UI.Client" Version="9.0.0" />
+	<PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="10.0.9" />
+	<PackageVersion Include="Microsoft.Extensions.Hosting.WindowsServices" Version="10.0.9" />
+	<PackageVersion Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.23.0" />
+	<PackageVersion Include="OpenIddict.AspNetCore" Version="7.5.0" />
+	<PackageVersion Include="Shared" Version="2026.5.7" />
+	<PackageVersion Include="Shared.Results.Web" Version="2026.5.7" />
+	<PackageVersion Include="Swashbuckle.AspNetCore" Version="10.2.1" />
+	<PackageVersion Include="Sentry.AspNetCore" Version="6.6.0" />
+	<PackageVersion Include="NLog.Web.AspNetCore" Version="6.1.3" />
+	<PackageVersion Include="HtmlAgilityPack" Version="1.12.4" />
+	<PackageVersion Include="Selenium.Support" Version="4.44.0" />
+	<PackageVersion Include="Selenium.WebDriver" Version="4.44.0" />
+	<PackageVersion Include="Reqnroll.NUnit" Version="3.3.4" />
+  </ItemGroup>
+</Project>

--- a/SecurityService.BusinessLogic/SecurityService.BusinessLogic.csproj
+++ b/SecurityService.BusinessLogic/SecurityService.BusinessLogic.csproj
@@ -5,17 +5,17 @@
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="MediatR" Version="14.1.0" />
-    <PackageReference Include="MessagingService.Client" Version="2026.4.3-build126" />
-    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="10.0.5" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.5" />
-    <PackageReference Include="OpenIddict.Abstractions" Version="7.3.0" />
-    <PackageReference Include="OpenIddict.Server" Version="7.3.0" />
-    <PackageReference Include="OpenIddict.Server.AspNetCore" Version="7.3.0" />
-    <PackageReference Include="OpenIddict.Validation.AspNetCore" Version="7.3.0" />
-    <PackageReference Include="Shared.Logger" Version="2026.5.5" />
-    <PackageReference Include="Shared.Results" Version="2026.5.5" />
-    <PackageReference Include="SimpleResults" Version="4.0.0" />
+    <PackageReference Include="MediatR" />
+    <PackageReference Include="MessagingService.Client" />
+    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" />
+    <PackageReference Include="OpenIddict.Abstractions" />
+    <PackageReference Include="OpenIddict.Server" />
+    <PackageReference Include="OpenIddict.Server.AspNetCore" />
+    <PackageReference Include="OpenIddict.Validation.AspNetCore" />
+    <PackageReference Include="Shared.Logger" />
+    <PackageReference Include="Shared.Results" />
+    <PackageReference Include="SimpleResults" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\SecurityService.Database\SecurityService.Database.csproj" />

--- a/SecurityService.Client/SecurityService.Client.csproj
+++ b/SecurityService.Client/SecurityService.Client.csproj
@@ -6,8 +6,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="ClientProxyBase" Version="2026.5.5" />
-    <PackageReference Include="Shared.Results" Version="2026.5.5" />
+    <PackageReference Include="ClientProxyBase" />
+    <PackageReference Include="Shared.Results" />
   </ItemGroup>
 
   <ItemGroup>

--- a/SecurityService.Database/SecurityService.Database.csproj
+++ b/SecurityService.Database/SecurityService.Database.csproj
@@ -5,15 +5,15 @@
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.5">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="10.0.5" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.5" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.5" />
-    <PackageReference Include="OpenIddict.EntityFrameworkCore" Version="7.3.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="10.0.5">
+    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" />
+    <PackageReference Include="OpenIddict.EntityFrameworkCore" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools">
 	    <PrivateAssets>all</PrivateAssets>
 	    <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/SecurityService.IntegrationTesting.Helpers/SecurityService.IntegrationTesting.Helpers.csproj
+++ b/SecurityService.IntegrationTesting.Helpers/SecurityService.IntegrationTesting.Helpers.csproj
@@ -7,10 +7,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.3" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.5" />
-	  <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="10.0.5" />
-    <PackageReference Include="Shared.IntegrationTesting" Version="2026.5.5" />
+	<PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" />
+	<PackageReference Include="Microsoft.EntityFrameworkCore.Relational" />
+	<PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" />
+	<PackageReference Include="Shared.IntegrationTesting" />
   </ItemGroup>
 
   <ItemGroup>

--- a/SecurityService.IntegrationTests/SecurityService.IntegrationTests.csproj
+++ b/SecurityService.IntegrationTests/SecurityService.IntegrationTests.csproj
@@ -8,32 +8,32 @@
 
   <ItemGroup>
     
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="10.0.3" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" />
 
-    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="10.0.5" />
+    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" />
     
-    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.3" />
+    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" />
     
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
     
-    <PackageReference Include="Reqnroll" Version="3.3.3" />
+    <PackageReference Include="Reqnroll" />
     
-    <PackageReference Include="Reqnroll.Tools.MsBuild.Generation" Version="3.3.3" />
+    <PackageReference Include="Reqnroll.Tools.MsBuild.Generation" />
 
-	  <PackageReference Include="NUnit" Version="4.5.1" />
-    <PackageReference Include="NUnit3TestAdapter" Version="6.1.0" />
-    <PackageReference Include="Reqnroll.NUnit" Version="3.3.3" />
+    <PackageReference Include="NUnit" />
+    <PackageReference Include="NUnit3TestAdapter" />
+    <PackageReference Include="Reqnroll.NUnit" />
 
-    <PackageReference Include="Shared.IntegrationTesting" Version="2026.5.5" />
-    <PackageReference Include="System.Data.SqlClient" Version="4.9.1" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.5" />
+    <PackageReference Include="Shared.IntegrationTesting" />
+    <PackageReference Include="System.Data.SqlClient" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" />
     
-    <PackageReference Include="coverlet.collector" Version="8.0.0">
+    <PackageReference Include="coverlet.collector">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Ductus.FluentDocker" Version="2.85.0" />
-    <PackageReference Include="Shouldly" Version="4.3.0" />
+    <PackageReference Include="Ductus.FluentDocker" />
+    <PackageReference Include="Shouldly" />
   </ItemGroup>
 
   <ItemGroup>

--- a/SecurityService.OpenIdConnect.IntegrationTests/Common/Hooks.cs
+++ b/SecurityService.OpenIdConnect.IntegrationTests/Common/Hooks.cs
@@ -101,8 +101,11 @@ namespace SecurityService.IntergrationTests.Common
             {
                 EdgeOptions options = new EdgeOptions();
                 options.AcceptInsecureCertificates = true;
-                options.AddArguments("--headless");
+                options.AddArguments("--headless=new");
                 options.AddArguments("--window-size=1280x1024");
+                options.AddArguments("--no-sandbox");
+                options.AddArguments("--disable-dev-shm-usage");
+                options.AddArguments("--disable-gpu");
                 await Retry.For(async () =>
                                 {
                                     this.WebDriver = new EdgeDriver(options);

--- a/SecurityService.OpenIdConnect.IntegrationTests/SecurityService.OpenIdConnect.IntegrationTests.csproj
+++ b/SecurityService.OpenIdConnect.IntegrationTests/SecurityService.OpenIdConnect.IntegrationTests.csproj
@@ -8,29 +8,29 @@
 
   <ItemGroup>
     
-    <PackageReference Include="HtmlAgilityPack" Version="1.12.4" />
-    
-    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.3" />
+    <PackageReference Include="HtmlAgilityPack" />
 
-	  <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
+    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" />
 
-    <PackageReference Include="Reqnroll" Version="3.3.3" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
 
-    <PackageReference Include="Reqnroll.Tools.MsBuild.Generation" Version="3.3.3" />
+    <PackageReference Include="Reqnroll" />
 
-	  <PackageReference Include="NUnit" Version="4.5.1" />
-    <PackageReference Include="NUnit3TestAdapter" Version="6.1.0" />
-    <PackageReference Include="Reqnroll.NUnit" Version="3.3.3" />
-    
-    <PackageReference Include="Selenium.Support" Version="4.41.0" />
-    <PackageReference Include="Selenium.WebDriver" Version="4.41.0" />
-    <PackageReference Include="Shared.IntegrationTesting" Version="2026.5.5" />
-    <PackageReference Include="coverlet.collector" Version="8.0.0">
+    <PackageReference Include="Reqnroll.Tools.MsBuild.Generation" />
+
+    <PackageReference Include="NUnit" />
+    <PackageReference Include="NUnit3TestAdapter" />
+    <PackageReference Include="Reqnroll.NUnit" />
+
+    <PackageReference Include="Selenium.Support" />
+    <PackageReference Include="Selenium.WebDriver" />
+    <PackageReference Include="Shared.IntegrationTesting" />
+    <PackageReference Include="coverlet.collector">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Ductus.FluentDocker" Version="2.85.0" />
-    <PackageReference Include="Shouldly" Version="4.3.0" />
+    <PackageReference Include="Ductus.FluentDocker" />
+    <PackageReference Include="Shouldly" />
   </ItemGroup>
 
   <ItemGroup>

--- a/SecurityService.SqlServerMigrations/SecurityService.SqlServerMigrations.csproj
+++ b/SecurityService.SqlServerMigrations/SecurityService.SqlServerMigrations.csproj
@@ -5,11 +5,11 @@
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.5">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.5" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\SecurityService.Database\SecurityService.Database.csproj" />

--- a/SecurityService.UnitTests/SecurityService.UnitTests.csproj
+++ b/SecurityService.UnitTests/SecurityService.UnitTests.csproj
@@ -6,16 +6,16 @@
     <IsPackable>false</IsPackable>
   </PropertyGroup>
   <ItemGroup>
-	  <PackageReference Include="coverlet.msbuild" Version="8.0.0">
-		  <PrivateAssets>all</PrivateAssets>
-		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-	  </PackageReference>
-	  <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.5" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
-    <PackageReference Include="Moq" Version="4.20.72" />
-    <PackageReference Include="Shouldly" Version="4.3.0" />
-    <PackageReference Include="xunit" Version="2.9.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
+        <PackageReference Include="coverlet.msbuild">
+            <PrivateAssets>all</PrivateAssets>
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
+        <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="Moq" />
+    <PackageReference Include="Shouldly" />
+    <PackageReference Include="xunit.v3" />
+    <PackageReference Include="xunit.runner.visualstudio">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/SecurityService.slnx
+++ b/SecurityService.slnx
@@ -1,4 +1,7 @@
 <Solution>
+  <Folder Name="/Solution Items/">
+    <File Path="Directory.Packages.props" />
+  </Folder>
   <Folder Name="/src/">
     <Project Path="SecurityService.BusinessLogic/SecurityService.BusinessLogic.csproj" />
     <Project Path="SecurityService.Database/SecurityService.Database.csproj" />

--- a/SecurityService/Dockerfile
+++ b/SecurityService/Dockerfile
@@ -13,7 +13,8 @@ COPY ["SecurityService.Database/SecurityService.Database.csproj", "SecurityServi
 COPY ["SecurityService.DataTransferObjects/SecurityService.DataTransferObjects.csproj", "SecurityService.DataTransferObjects/"]
 COPY ["SecurityService.Models/SecurityService.Models.csproj", "SecurityService.Models/"]
 COPY ["SecurityService.SqlServerMigrations/SecurityService.SqlServerMigrations.csproj", "SecurityService.SqlServerMigrations/"]
-
+COPY ["Directory.Packages.props", "."]
+COPY . .
 RUN dotnet restore "SecurityService/SecurityService.csproj"
 
 COPY . .

--- a/SecurityService/DockerfileWindows
+++ b/SecurityService/DockerfileWindows
@@ -13,6 +13,8 @@ COPY ["SecurityService.Database/SecurityService.Database.csproj", "SecurityServi
 COPY ["SecurityService.DataTransferObjects/SecurityService.DataTransferObjects.csproj", "SecurityService.DataTransferObjects/"]
 COPY ["SecurityService.Models/SecurityService.Models.csproj", "SecurityService.Models/"]
 COPY ["SecurityService.SqlServerMigrations/SecurityService.SqlServerMigrations.csproj", "SecurityService.SqlServerMigrations/"]
+COPY ["Directory.Packages.props", "."]
+COPY . .
 
 RUN dotnet restore "SecurityService/SecurityService.csproj"
 COPY . .

--- a/SecurityService/SecurityService.csproj
+++ b/SecurityService/SecurityService.csproj
@@ -13,28 +13,28 @@
     <Content Remove="Pages\Account\ExternalLogin\Index.cshtml" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="AspNetCore.HealthChecks.UI.Client" Version="9.0.0" />
-    <PackageReference Include="MediatR" Version="14.1.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="10.0.5" />
-    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="10.0.5" />
-    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.5" />
-    <PackageReference Include="Microsoft.Extensions.Hosting.WindowsServices" Version="10.0.5" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.5">
+    <PackageReference Include="AspNetCore.HealthChecks.UI.Client" />
+    <PackageReference Include="MediatR" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" />
+    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" />
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" />
+    <PackageReference Include="Microsoft.Extensions.Hosting.WindowsServices" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.5" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.5" />
-    <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.23.0" />
-    <PackageReference Include="OpenIddict.AspNetCore" Version="7.3.0" />
-    <PackageReference Include="OpenIddict.EntityFrameworkCore" Version="7.3.0" />
-    <PackageReference Include="OpenIddict.Server.AspNetCore" Version="7.3.0" />
-    <PackageReference Include="OpenIddict.Validation.AspNetCore" Version="7.3.0" />
-    <PackageReference Include="Shared" Version="2026.5.5" />
-    <PackageReference Include="Shared.Results.Web" Version="2026.5.5" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="10.0.1" />
-    <PackageReference Include="Sentry.AspNetCore" Version="6.2.0" />
-    <PackageReference Include="NLog.Web.AspNetCore" Version="6.1.2" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" />
+    <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" />
+    <PackageReference Include="OpenIddict.AspNetCore" />
+    <PackageReference Include="OpenIddict.EntityFrameworkCore" />
+    <PackageReference Include="OpenIddict.Server.AspNetCore" />
+    <PackageReference Include="OpenIddict.Validation.AspNetCore" />
+    <PackageReference Include="Shared" />
+    <PackageReference Include="Shared.Results.Web" />
+    <PackageReference Include="Swashbuckle.AspNetCore" />
+    <PackageReference Include="Sentry.AspNetCore" />
+    <PackageReference Include="NLog.Web.AspNetCore" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\SecurityService.SqlServerMigrations\SecurityService.SqlServerMigrations.csproj" />

--- a/SecurityServiceTestUI/Dockerfile
+++ b/SecurityServiceTestUI/Dockerfile
@@ -14,6 +14,8 @@ RUN sed -i "s|NUGET_TOKEN|${NUGET_TOKEN}|g" NuGet.Config
 
 COPY ["Certificates/*.*", "Certificates/"]
 COPY ["SecurityServiceTestUI/SecurityServiceTestUI.csproj", "SecurityServiceTestUI/"]
+COPY ["Directory.Packages.props", "."]
+COPY . .
 RUN dotnet restore "SecurityServiceTestUI/SecurityServiceTestUI.csproj"
 COPY . .
 WORKDIR "/src/SecurityServiceTestUI"

--- a/SecurityServiceTestUI/DockerfileWindows
+++ b/SecurityServiceTestUI/DockerfileWindows
@@ -9,6 +9,8 @@ WORKDIR /src
 COPY ["SecurityService/NuGet.Config", "."]
 COPY ["Certificates/*.*", "Certificates/"]
 COPY ["SecurityServiceTestUI/SecurityServiceTestUI.csproj", "SecurityServiceTestUI/"]
+COPY ["Directory.Packages.props", "."]
+COPY . .
 RUN dotnet restore "SecurityServiceTestUI/SecurityServiceTestUI.csproj"
 COPY . .
 WORKDIR "/src/SecurityServiceTestUI"

--- a/SecurityServiceTestUI/SecurityServiceTestUI.csproj
+++ b/SecurityServiceTestUI/SecurityServiceTestUI.csproj
@@ -7,11 +7,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AspNetCore.HealthChecks.UI.Client" Version="9.0.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="10.0.3" />
-    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.3" />
-    <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.23.0" />
-    <PackageReference Include="Shared" Version="2026.5.5" />
+    <PackageReference Include="AspNetCore.HealthChecks.UI.Client" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" />
+    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" />
+    <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" />
+    <PackageReference Include="Shared" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Migrated all package version management to Directory.Packages.props, removing explicit version numbers from .csproj files. Updated the solution and Dockerfiles to include the new props file. This change streamlines dependency management and ensures consistent package versions across all projects.

closes #1634
closes #1644 